### PR TITLE
allow for through cut logo

### DIFF
--- a/scad/config.scad
+++ b/scad/config.scad
@@ -114,7 +114,7 @@ vertical_plate_position      = undef;                   // y position from the h
 // logo
 // ---------------------------------------------------------------- //
 dxf_logo   = "logo.dxf"; // path to DXF logo
-logo_depth = 2;          // logo pocket depth
+logo_depth = 2;          // logo pocket depth (set to undef for through cut)
 
 
 // ---------------------------------------------------------------- //

--- a/scad/parts/vertical_plate.scad
+++ b/scad/parts/vertical_plate.scad
@@ -95,12 +95,13 @@ module vertical_plate_holes() {
     triangle_holes();
     z_rod_holder_holes();
     triangle_connectors_holes();
+    if (logo_depth == undef) logo();
 }
 
 // pockets
 module vertical_plate_pockets() {
     color(pockets_color) 
-        logo();
+        if (logo_depth != undef) logo();
 }
 
 // vertical plate 2D
@@ -128,9 +129,8 @@ module vertical_plate_3D() {
                 vertical_plate_2D();
             translate([0, 0, h - d])
                 linear_extrude(d)
-                     logo();
+                    if (logo_depth != undef) logo();
         }
-    
 }
 
 // vertical plate


### PR DESCRIPTION
Please accept this pull request to make through cutting the logo a little bit more clean than setting `logo_depth = sheet_thickness`

This is enabled by setting `logo_depth = undef`
