### PR TITLE
add option to go pocketless

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -148,6 +148,10 @@ call([openscadPath,
     '-D', 'output_version='+str(outputVersion),
     mainScadFile]);
 
+# if the pockets layer does not exist (pockets_depth = 0), then tmpFile2 should be empty
+if ~os.path.isfile(tmpFile2):
+    tmpFile2 = '';
+
 call(['python', odmtPath, 
     'input', tmpFile1, tmpFile2,
     '--output', outputFile]);

--- a/scad/config.scad
+++ b/scad/config.scad
@@ -43,7 +43,7 @@ parts_margin = 10;
 // drawing settings
 // ---------------------------------------------------------------- //
 sheet_thickness = 16;                    // raw sheet thickness
-pockets_depth   = 6;                     // pockets depth
+pockets_depth   = 6;                     // pockets depth (set to 0 for no pockets, in this case you'll need to print 4x y_rod_holder.OPTIONAL.stl)
 pockets_color   = "RoyalBlue";           // pockets color
 connector_size  = [20, sheet_thickness]; // pockets/fingers [width, height]
 

--- a/scad/parts/horizontal_plate.scad
+++ b/scad/parts/horizontal_plate.scad
@@ -249,26 +249,28 @@ module horizontal_plate_holes() {
 
 // pockets
 module horizontal_plate_pockets() {
-    color(pockets_color) {
-        difference() {
-            endstop_mount();
-            if (output_mode != 3) {
-                y_endstop_holes();
+    if (pockets_depth != 0) {
+        color(pockets_color) {
+            difference() {
+                endstop_mount();
+                if (output_mode != 3) {
+                    y_endstop_holes();
+                }
             }
-        }
-        difference() {
-            y_idler_pocket();
-            if (output_mode != 3) {
-                y_idler_hole();
+            difference() {
+                y_idler_pocket();
+                if (output_mode != 3) {
+                    y_idler_hole();
+                }
             }
-        }
-        difference() {
-            y_motor_pocket();
-            if (output_mode != 3) {
-                y_motor_mount();
+            difference() {
+                y_motor_pocket();
+                if (output_mode != 3) {
+                    y_motor_mount();
+                }
             }
+            y_rod_pockets();
         }
-        y_rod_pockets();
     }
 }
 
@@ -317,14 +319,17 @@ module horizontal_plate() {
         horizontal_plate_2D();
     } 
     else if (output_mode == 3) {
-        difference() {
-            if (output_version == 1) {
-                horizontal_plate_2D();
+        if (pockets_depth != 0) {
+            difference() {
+                if (output_version == 1) {
+                    horizontal_plate_2D();
+                }
+                horizontal_plate_pockets();
             }
-            horizontal_plate_pockets();
+        } else {
+            echo("Can't output pocket layer, there are no pockets (pockets_depth = 0)");
         }
-    } 
-    else {
+    } else {
         horizontal_plate_3D();
     }
 }

--- a/scad/parts/vertical_plate.scad
+++ b/scad/parts/vertical_plate.scad
@@ -100,8 +100,10 @@ module vertical_plate_holes() {
 
 // pockets
 module vertical_plate_pockets() {
-    color(pockets_color) 
-        if (logo_depth != undef) logo();
+    if (pockets_depth != 0) {
+        color(pockets_color)
+            if (logo_depth != undef) logo();
+    }
 }
 
 // vertical plate 2D
@@ -150,14 +152,17 @@ module vertical_plate() {
         vertical_plate_2D();
     } 
     else if (output_mode == 3) {
-        difference() {
-            if (output_version == 1) {
-                vertical_plate_2D();
+        if (pockets_depth != 0) {
+            difference() {
+                if (output_version == 1) {
+                    vertical_plate_2D();
+                }
+                vertical_plate_pockets();
             }
-            vertical_plate_pockets();
+        } else {
+            echo("Can't output pocket layer, there are no pockets (pockets_depth = 0)");
         }
-    } 
-    else {
+    } else {
         vertical_plate_3D();
     }
 }

--- a/scad/parts/y_carriage.scad
+++ b/scad/parts/y_carriage.scad
@@ -228,9 +228,11 @@ module y_carriage_3D() {
 
 // pockets
 module y_carriage_pockets() {
-    color(pockets_color) render() intersection() {
-        y_carriage_2D();
-        y_carriage_holes_pocket();
+    if (pockets_depth != 0) {
+        color(pockets_color) render() intersection() {
+            y_carriage_2D();
+            y_carriage_holes_pocket();
+        }
     }
 }
 
@@ -251,14 +253,17 @@ module y_carriage() {
         y_carriage_2D();
     } 
     else if (output_mode == 3) {
-        difference() {
-            if (output_version == 1) {
-                y_carriage_2D();
+        if (pockets_depth != 0) {
+            difference() {
+                if (output_version == 1) {
+                    y_carriage_2D();
+                }
+                y_carriage_pockets();
             }
-            y_carriage_pockets();
+        } else {
+            echo("Can't output pocket layer, there are no pockets (pockets_depth = 0)");
         }
-    } 
-    else {
+    } else {
         y_carriage_3D();
     }
 }

--- a/scad/parts/y_rod_holders.scad
+++ b/scad/parts/y_rod_holders.scad
@@ -1,0 +1,14 @@
+// units in mm
+// y-rod holders (4x to be printed in case pockets_depth = 0)
+include <../config.scad>
+blockX = 24;
+blockY = 24;
+blockZ = 12;
+
+difference(){
+    translate([-blockX/2,0,0]) cube([blockX,blockY,blockZ]);
+    translate([0,0,y_rod_pockets_size[0]/2]) rotate([-90,0,0]) cylinder(d=y_rod_pockets_size[0],h=y_rod_pockets_size[1]);
+    translate([y_rod_holes_margin+y_rod_pockets_size[0]/2,y_rod_pockets_size[1]/2,0]) cylinder(r=m3_screw_radius,h=blockZ);
+    translate([-y_rod_holes_margin-y_rod_pockets_size[0]/2,y_rod_pockets_size[1]/2,0]) cylinder(r=m3_screw_radius,h=blockZ);
+}
+

--- a/stl/y_rod_holder.OPTIONAL.stl
+++ b/stl/y_rod_holder.OPTIONAL.stl
@@ -1,0 +1,4342 @@
+solid OpenSCAD_Model
+  facet normal -1 0 0
+    outer loop
+      vertex -12 0 0
+      vertex -12 24 12
+      vertex -12 24 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -12 24 12
+      vertex -12 0 0
+      vertex -12 0 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 9.5 10 12
+      vertex 12 0 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 9.48817 10.188 12
+      vertex 9.5 10 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 9.45287 10.373 12
+      vertex 9.48817 10.188 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 9.39466 10.5522 12
+      vertex 9.45287 10.373 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 9.31446 10.7226 12
+      vertex 9.39466 10.5522 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 9.21352 10.8817 12
+      vertex 9.31446 10.7226 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 9.09345 11.0268 12
+      vertex 9.21352 10.8817 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 8.95614 11.1558 12
+      vertex 9.09345 11.0268 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 8.80374 11.2665 12
+      vertex 8.95614 11.1558 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 8.63867 11.3572 12
+      vertex 8.80374 11.2665 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 8.46352 11.4266 12
+      vertex 8.63867 11.3572 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 8.28107 11.4734 12
+      vertex 8.46352 11.4266 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 8.09418 11.497 12
+      vertex 8.28107 11.4734 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 7.90581 11.497 12
+      vertex 8.09418 11.497 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 7.71893 11.4734 12
+      vertex 7.90581 11.497 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 7.53647 11.4266 12
+      vertex 7.71893 11.4734 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 7.36133 11.3572 12
+      vertex 7.53647 11.4266 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 24 12
+      vertex 7.19626 11.2665 12
+      vertex 7.36133 11.3572 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.19626 11.2665 12
+      vertex 7.19626 11.2665 12
+      vertex 12 24 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.19626 11.2665 12
+      vertex -7.19626 11.2665 12
+      vertex 7.04386 11.1558 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.04386 11.1558 12
+      vertex -7.04386 11.1558 12
+      vertex 6.90655 11.0268 12
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -6.90655 11.0268 12
+      vertex 6.90655 11.0268 12
+      vertex -7.04386 11.1558 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.90655 11.0268 12
+      vertex -6.90655 11.0268 12
+      vertex 6.78647 10.8817 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.51183 10.188 12
+      vertex -6.5 10 12
+      vertex 6.5 10 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.51183 10.188 12
+      vertex 6.51183 10.188 12
+      vertex 6.54712 10.373 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.54712 10.373 12
+      vertex 6.54712 10.373 12
+      vertex 6.60534 10.5522 12
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -6.78647 10.8817 12
+      vertex 6.78647 10.8817 12
+      vertex -6.90655 11.0268 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.51183 10.188 12
+      vertex -6.51183 10.188 12
+      vertex -6.5 10 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.54712 10.373 12
+      vertex -6.54712 10.373 12
+      vertex -6.51183 10.188 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.60534 10.5522 12
+      vertex -6.60534 10.5522 12
+      vertex -6.54712 10.373 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.60534 10.5522 12
+      vertex -6.68554 10.7226 12
+      vertex -6.60534 10.5522 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.68554 10.7226 12
+      vertex -6.68554 10.7226 12
+      vertex 6.60534 10.5522 12
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -6.68554 10.7226 12
+      vertex 6.68554 10.7226 12
+      vertex -6.78647 10.8817 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.78647 10.8817 12
+      vertex -6.78647 10.8817 12
+      vertex 6.68554 10.7226 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.04386 11.1558 12
+      vertex -7.19626 11.2665 12
+      vertex -7.04386 11.1558 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12 24 12
+      vertex -7.19626 11.2665 12
+      vertex 12 24 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.19626 11.2665 12
+      vertex -12 24 12
+      vertex -7.36133 11.3572 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.36133 11.3572 12
+      vertex -12 24 12
+      vertex -7.53647 11.4266 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.53647 11.4266 12
+      vertex -12 24 12
+      vertex -7.71893 11.4734 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.71893 11.4734 12
+      vertex -12 24 12
+      vertex -7.90581 11.497 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.90581 11.497 12
+      vertex -12 24 12
+      vertex -8.09418 11.497 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.09418 11.497 12
+      vertex -12 24 12
+      vertex -8.28107 11.4734 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.28107 11.4734 12
+      vertex -12 24 12
+      vertex -8.46352 11.4266 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.46352 11.4266 12
+      vertex -12 24 12
+      vertex -8.63867 11.3572 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.48817 10.188 12
+      vertex -12 24 12
+      vertex -9.5 10 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.45287 10.373 12
+      vertex -12 24 12
+      vertex -9.48817 10.188 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.39466 10.5522 12
+      vertex -12 24 12
+      vertex -9.45287 10.373 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.31446 10.7226 12
+      vertex -12 24 12
+      vertex -9.39466 10.5522 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.21352 10.8817 12
+      vertex -12 24 12
+      vertex -9.31446 10.7226 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.09345 11.0268 12
+      vertex -12 24 12
+      vertex -9.21352 10.8817 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.95614 11.1558 12
+      vertex -12 24 12
+      vertex -9.09345 11.0268 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.80374 11.2665 12
+      vertex -12 24 12
+      vertex -8.95614 11.1558 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.63867 11.3572 12
+      vertex -12 24 12
+      vertex -8.80374 11.2665 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.48817 9.812 12
+      vertex 12 0 12
+      vertex 9.5 10 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.45287 9.62696 12
+      vertex 12 0 12
+      vertex 9.48817 9.812 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.39466 9.44781 12
+      vertex 12 0 12
+      vertex 9.45287 9.62696 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.31446 9.27737 12
+      vertex 12 0 12
+      vertex 9.39466 9.44781 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.21352 9.11832 12
+      vertex 12 0 12
+      vertex 9.31446 9.27737 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.09345 8.97318 12
+      vertex 12 0 12
+      vertex 9.21352 9.11832 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.95614 8.84423 12
+      vertex 12 0 12
+      vertex 9.09345 8.97318 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.80374 8.73351 12
+      vertex 12 0 12
+      vertex 8.95614 8.84423 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.63867 8.64276 12
+      vertex 12 0 12
+      vertex 8.80374 8.73351 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.46352 8.57341 12
+      vertex 12 0 12
+      vertex 8.63867 8.64276 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.28107 8.52657 12
+      vertex 12 0 12
+      vertex 8.46352 8.57341 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.09418 8.50296 12
+      vertex 12 0 12
+      vertex 8.28107 8.52657 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.90581 8.50296 12
+      vertex 12 0 12
+      vertex 8.09418 8.50296 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.71893 8.52657 12
+      vertex 12 0 12
+      vertex 7.90581 8.50296 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.53647 8.57341 12
+      vertex 12 0 12
+      vertex 7.71893 8.52657 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.36133 8.64276 12
+      vertex 12 0 12
+      vertex 7.53647 8.57341 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.19626 8.73351 12
+      vertex 12 0 12
+      vertex 7.36133 8.64276 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.04386 8.84423 12
+      vertex 12 0 12
+      vertex 7.19626 8.73351 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.04386 8.84423 12
+      vertex 7.04386 8.84423 12
+      vertex 6.90655 8.97318 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.90655 8.97318 12
+      vertex 6.90655 8.97318 12
+      vertex 6.78647 9.11832 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.78647 9.11832 12
+      vertex 6.78647 9.11832 12
+      vertex 6.68554 9.27737 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.5 10 12
+      vertex 6.51183 9.812 12
+      vertex 6.5 10 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.51183 9.812 12
+      vertex 6.51183 9.812 12
+      vertex -6.5 10 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.51183 9.812 12
+      vertex -6.51183 9.812 12
+      vertex 6.54712 9.62696 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.54712 9.62696 12
+      vertex 6.54712 9.62696 12
+      vertex -6.51183 9.812 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.54712 9.62696 12
+      vertex -6.54712 9.62696 12
+      vertex 6.60534 9.44781 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.60534 9.44781 12
+      vertex 6.60534 9.44781 12
+      vertex -6.54712 9.62696 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.60534 9.44781 12
+      vertex -6.60534 9.44781 12
+      vertex 6.68554 9.27737 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.68554 9.27737 12
+      vertex 6.68554 9.27737 12
+      vertex -6.60534 9.44781 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.78647 9.11832 12
+      vertex 6.68554 9.27737 12
+      vertex -6.68554 9.27737 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.78647 9.11832 12
+      vertex -6.78647 9.11832 12
+      vertex -6.90655 8.97318 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.90655 8.97318 12
+      vertex -6.90655 8.97318 12
+      vertex -7.04386 8.84423 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.04386 8.84423 12
+      vertex -7.04386 8.84423 12
+      vertex 12 0 12
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.19626 8.73351 12
+      vertex 12 0 12
+      vertex -7.04386 8.84423 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -7.19626 8.73351 12
+      vertex -7.36133 8.64276 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -7.36133 8.64276 12
+      vertex -7.53647 8.57341 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -7.53647 8.57341 12
+      vertex -7.71893 8.52657 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -7.71893 8.52657 12
+      vertex -7.90581 8.50296 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -7.90581 8.50296 12
+      vertex -8.09418 8.50296 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -8.09418 8.50296 12
+      vertex -8.28107 8.52657 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -8.28107 8.52657 12
+      vertex -8.46352 8.57341 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -8.46352 8.57341 12
+      vertex -8.63867 8.64276 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 12
+      vertex -9.5 10 12
+      vertex -12 24 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.19626 8.73351 12
+      vertex -12 0 12
+      vertex 12 0 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.80374 8.73351 12
+      vertex -12 0 12
+      vertex -8.63867 8.64276 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.95614 8.84423 12
+      vertex -12 0 12
+      vertex -8.80374 8.73351 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.09345 8.97318 12
+      vertex -12 0 12
+      vertex -8.95614 8.84423 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.21352 9.11832 12
+      vertex -12 0 12
+      vertex -9.09345 8.97318 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.31446 9.27737 12
+      vertex -12 0 12
+      vertex -9.21352 9.11832 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.39466 9.44781 12
+      vertex -12 0 12
+      vertex -9.31446 9.27737 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.45287 9.62696 12
+      vertex -12 0 12
+      vertex -9.39466 9.44781 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.48817 9.812 12
+      vertex -12 0 12
+      vertex -9.45287 9.62696 12
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.5 10 12
+      vertex -12 0 12
+      vertex -9.48817 9.812 12
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 12 0 12
+      vertex 12 24 0
+      vertex 12 24 12
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 12 24 0
+      vertex 12 0 12
+      vertex 12 0 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 12 24 0
+      vertex -12 24 12
+      vertex 12 24 12
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12 24 12
+      vertex 12 24 0
+      vertex -12 24 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 9.5 10 0
+      vertex 12 24 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 9.48817 9.812 0
+      vertex 9.5 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 9.45287 9.62696 0
+      vertex 9.48817 9.812 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 9.39466 9.44781 0
+      vertex 9.45287 9.62696 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 9.31446 9.27737 0
+      vertex 9.39466 9.44781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 9.21352 9.11832 0
+      vertex 9.31446 9.27737 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 9.09345 8.97318 0
+      vertex 9.21352 9.11832 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 8.95614 8.84423 0
+      vertex 9.09345 8.97318 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 8.80374 8.73351 0
+      vertex 8.95614 8.84423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 8.63867 8.64276 0
+      vertex 8.80374 8.73351 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 8.46352 8.57341 0
+      vertex 8.63867 8.64276 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 8.28107 8.52657 0
+      vertex 8.46352 8.57341 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 8.09418 8.50296 0
+      vertex 8.28107 8.52657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 7.90581 8.50296 0
+      vertex 8.09418 8.50296 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 7.71893 8.52657 0
+      vertex 7.90581 8.50296 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 7.53647 8.57341 0
+      vertex 7.71893 8.52657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 7.36133 8.64276 0
+      vertex 7.53647 8.57341 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 7.19626 8.73351 0
+      vertex 7.36133 8.64276 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex 7.04386 8.84423 0
+      vertex 7.19626 8.73351 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.04386 8.84423 0
+      vertex 7.04386 8.84423 0
+      vertex 12 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.04386 8.84423 0
+      vertex -7.04386 8.84423 0
+      vertex 6.90655 8.97318 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -6.90655 8.97318 0
+      vertex 6.90655 8.97318 0
+      vertex -7.04386 8.84423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.51183 9.812 0
+      vertex -6.5 10 0
+      vertex 6.5 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.51183 9.812 0
+      vertex 6.51183 9.812 0
+      vertex 6.54712 9.62696 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.54712 9.62696 0
+      vertex 6.54712 9.62696 0
+      vertex 6.60534 9.44781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.60534 9.44781 0
+      vertex 6.60534 9.44781 0
+      vertex 6.68554 9.27737 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.90655 8.97318 0
+      vertex -6.90655 8.97318 0
+      vertex 6.78647 9.11832 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.51183 9.812 0
+      vertex -6.51183 9.812 0
+      vertex -6.5 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.54712 9.62696 0
+      vertex -6.54712 9.62696 0
+      vertex -6.51183 9.812 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.60534 9.44781 0
+      vertex -6.60534 9.44781 0
+      vertex -6.54712 9.62696 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.68554 9.27737 0
+      vertex -6.68554 9.27737 0
+      vertex -6.60534 9.44781 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.68554 9.27737 0
+      vertex -6.78647 9.11832 0
+      vertex -6.68554 9.27737 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.78647 9.11832 0
+      vertex -6.78647 9.11832 0
+      vertex 6.68554 9.27737 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -6.78647 9.11832 0
+      vertex 6.78647 9.11832 0
+      vertex -6.90655 8.97318 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12 0 0
+      vertex -7.19626 8.73351 0
+      vertex -7.04386 8.84423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 0 0
+      vertex -7.19626 8.73351 0
+      vertex 12 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.19626 8.73351 0
+      vertex -12 0 0
+      vertex -7.36133 8.64276 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.36133 8.64276 0
+      vertex -12 0 0
+      vertex -7.53647 8.57341 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.53647 8.57341 0
+      vertex -12 0 0
+      vertex -7.71893 8.52657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.71893 8.52657 0
+      vertex -12 0 0
+      vertex -7.90581 8.50296 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.90581 8.50296 0
+      vertex -12 0 0
+      vertex -8.09418 8.50296 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.09418 8.50296 0
+      vertex -12 0 0
+      vertex -8.28107 8.52657 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.28107 8.52657 0
+      vertex -12 0 0
+      vertex -8.46352 8.57341 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.48817 9.812 0
+      vertex -12 0 0
+      vertex -9.5 10 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.45287 9.62696 0
+      vertex -12 0 0
+      vertex -9.48817 9.812 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.39466 9.44781 0
+      vertex -12 0 0
+      vertex -9.45287 9.62696 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.31446 9.27737 0
+      vertex -12 0 0
+      vertex -9.39466 9.44781 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.21352 9.11832 0
+      vertex -12 0 0
+      vertex -9.31446 9.27737 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.09345 8.97318 0
+      vertex -12 0 0
+      vertex -9.21352 9.11832 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.95614 8.84423 0
+      vertex -12 0 0
+      vertex -9.09345 8.97318 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.80374 8.73351 0
+      vertex -12 0 0
+      vertex -8.95614 8.84423 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.63867 8.64276 0
+      vertex -12 0 0
+      vertex -8.80374 8.73351 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.46352 8.57341 0
+      vertex -12 0 0
+      vertex -8.63867 8.64276 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.48817 10.188 0
+      vertex 12 24 0
+      vertex 9.5 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.45287 10.373 0
+      vertex 12 24 0
+      vertex 9.48817 10.188 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.39466 10.5522 0
+      vertex 12 24 0
+      vertex 9.45287 10.373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.31446 10.7226 0
+      vertex 12 24 0
+      vertex 9.39466 10.5522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.21352 10.8817 0
+      vertex 12 24 0
+      vertex 9.31446 10.7226 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.09345 11.0268 0
+      vertex 12 24 0
+      vertex 9.21352 10.8817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.95614 11.1558 0
+      vertex 12 24 0
+      vertex 9.09345 11.0268 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.80374 11.2665 0
+      vertex 12 24 0
+      vertex 8.95614 11.1558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.63867 11.3572 0
+      vertex 12 24 0
+      vertex 8.80374 11.2665 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.46352 11.4266 0
+      vertex 12 24 0
+      vertex 8.63867 11.3572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.28107 11.4734 0
+      vertex 12 24 0
+      vertex 8.46352 11.4266 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.09418 11.497 0
+      vertex 12 24 0
+      vertex 8.28107 11.4734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.90581 11.497 0
+      vertex 12 24 0
+      vertex 8.09418 11.497 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.71893 11.4734 0
+      vertex 12 24 0
+      vertex 7.90581 11.497 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.53647 11.4266 0
+      vertex 12 24 0
+      vertex 7.71893 11.4734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.36133 11.3572 0
+      vertex 12 24 0
+      vertex 7.53647 11.4266 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.19626 11.2665 0
+      vertex 12 24 0
+      vertex 7.36133 11.3572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.19626 11.2665 0
+      vertex 7.19626 11.2665 0
+      vertex 7.04386 11.1558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.04386 11.1558 0
+      vertex 7.04386 11.1558 0
+      vertex 6.90655 11.0268 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.90655 11.0268 0
+      vertex 6.90655 11.0268 0
+      vertex 6.78647 10.8817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.78647 10.8817 0
+      vertex 6.78647 10.8817 0
+      vertex 6.68554 10.7226 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.68554 10.7226 0
+      vertex 6.68554 10.7226 0
+      vertex 6.60534 10.5522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.5 10 0
+      vertex 6.51183 10.188 0
+      vertex 6.5 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.51183 10.188 0
+      vertex 6.51183 10.188 0
+      vertex -6.5 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.51183 10.188 0
+      vertex -6.51183 10.188 0
+      vertex 6.54712 10.373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.54712 10.373 0
+      vertex 6.54712 10.373 0
+      vertex -6.51183 10.188 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.54712 10.373 0
+      vertex -6.54712 10.373 0
+      vertex 6.60534 10.5522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.60534 10.5522 0
+      vertex 6.60534 10.5522 0
+      vertex -6.54712 10.373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.68554 10.7226 0
+      vertex 6.60534 10.5522 0
+      vertex -6.60534 10.5522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.68554 10.7226 0
+      vertex -6.68554 10.7226 0
+      vertex -6.78647 10.8817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.78647 10.8817 0
+      vertex -6.78647 10.8817 0
+      vertex -6.90655 11.0268 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.90655 11.0268 0
+      vertex -6.90655 11.0268 0
+      vertex -7.04386 11.1558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.19626 11.2665 0
+      vertex 7.04386 11.1558 0
+      vertex -7.04386 11.1558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.19626 11.2665 0
+      vertex -7.19626 11.2665 0
+      vertex 12 24 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -7.19626 11.2665 0
+      vertex -7.36133 11.3572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -7.36133 11.3572 0
+      vertex -7.53647 11.4266 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -7.53647 11.4266 0
+      vertex -7.71893 11.4734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -7.71893 11.4734 0
+      vertex -7.90581 11.497 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -7.90581 11.497 0
+      vertex -8.09418 11.497 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -8.09418 11.497 0
+      vertex -8.28107 11.4734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -8.28107 11.4734 0
+      vertex -8.46352 11.4266 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -8.46352 11.4266 0
+      vertex -8.63867 11.3572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -8.63867 11.3572 0
+      vertex -8.80374 11.2665 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 0 0
+      vertex -9.48817 10.188 0
+      vertex -9.5 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 24 0
+      vertex -9.48817 10.188 0
+      vertex -12 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.19626 11.2665 0
+      vertex -12 24 0
+      vertex 12 24 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.95614 11.1558 0
+      vertex -12 24 0
+      vertex -8.80374 11.2665 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.09345 11.0268 0
+      vertex -12 24 0
+      vertex -8.95614 11.1558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.21352 10.8817 0
+      vertex -12 24 0
+      vertex -9.09345 11.0268 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.31446 10.7226 0
+      vertex -12 24 0
+      vertex -9.21352 10.8817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.39466 10.5522 0
+      vertex -12 24 0
+      vertex -9.31446 10.7226 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.45287 10.373 0
+      vertex -12 24 0
+      vertex -9.39466 10.5522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.48817 10.188 0
+      vertex -12 24 0
+      vertex -9.45287 10.373 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -0.251162 0 7.99211
+      vertex 12 0 12
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -0.749525 0 7.92915
+      vertex -0.251162 0 7.99211
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -1.23607 0 7.80423
+      vertex -0.749525 0 7.92915
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -1.70312 0 7.61931
+      vertex -1.23607 0 7.80423
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -2.14331 0 7.37731
+      vertex -1.70312 0 7.61931
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -2.5497 0 7.08205
+      vertex -2.14331 0 7.37731
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -2.91587 0 6.73819
+      vertex -2.5497 0 7.08205
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -3.23607 0 6.35114
+      vertex -2.91587 0 6.73819
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -3.50523 0 5.92701
+      vertex -3.23607 0 6.35114
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -3.71911 0 5.4725
+      vertex -3.50523 0 5.92701
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 12
+      vertex -3.87433 0 4.99476
+      vertex -3.71911 0 5.4725
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -12 0 0
+      vertex -3.87433 0 4.99476
+      vertex -12 0 12
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.87433 0 4.99476
+      vertex -12 0 0
+      vertex -3.96846 0 4.50133
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.96846 0 4.50133
+      vertex -12 0 0
+      vertex -4 0 4
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -4 0 4
+      vertex -12 0 0
+      vertex -3.96846 0 3.49867
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -3.96846 0 3.49867
+      vertex -12 0 0
+      vertex -3.87433 0 3.00524
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -3.87433 0 3.00524
+      vertex -12 0 0
+      vertex -3.71911 0 2.5275
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -3.71911 0 2.5275
+      vertex -12 0 0
+      vertex -3.50523 0 2.07298
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -3.50523 0 2.07298
+      vertex -12 0 0
+      vertex -3.23607 0 1.64886
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.251162 0 0.00789261
+      vertex -12 0 0
+      vertex 0.251162 0 0.00789261
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.749525 0 0.0708504
+      vertex -12 0 0
+      vertex -0.251162 0 0.00789261
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.23607 0 0.195773
+      vertex -12 0 0
+      vertex -0.749525 0 0.0708504
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.70312 0 0.380692
+      vertex -12 0 0
+      vertex -1.23607 0 0.195773
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.14331 0 0.622688
+      vertex -12 0 0
+      vertex -1.70312 0 0.380692
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.5497 0 0.917947
+      vertex -12 0 0
+      vertex -2.14331 0 0.622688
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.91587 0 1.26181
+      vertex -12 0 0
+      vertex -2.5497 0 0.917947
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -3.23607 0 1.64886
+      vertex -12 0 0
+      vertex -2.91587 0 1.26181
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.251162 0 7.99211
+      vertex 12 0 12
+      vertex -0.251162 0 7.99211
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.749525 0 7.92915
+      vertex 12 0 12
+      vertex 0.251162 0 7.99211
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.23607 0 7.80423
+      vertex 12 0 12
+      vertex 0.749525 0 7.92915
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.70312 0 7.61931
+      vertex 12 0 12
+      vertex 1.23607 0 7.80423
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 2.14331 0 7.37731
+      vertex 12 0 12
+      vertex 1.70312 0 7.61931
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 2.5497 0 7.08205
+      vertex 12 0 12
+      vertex 2.14331 0 7.37731
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 2.91587 0 6.73819
+      vertex 12 0 12
+      vertex 2.5497 0 7.08205
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3.23607 0 6.35114
+      vertex 12 0 12
+      vertex 2.91587 0 6.73819
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3.50523 0 5.92701
+      vertex 12 0 12
+      vertex 3.23607 0 6.35114
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3.71911 0 5.4725
+      vertex 12 0 12
+      vertex 3.50523 0 5.92701
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3.87433 0 4.99476
+      vertex 12 0 12
+      vertex 3.71911 0 5.4725
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 3.87433 0 4.99476
+      vertex 3.96846 0 4.50133
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 3.96846 0 4.50133
+      vertex 4 0 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 4 0 4
+      vertex 3.96846 0 3.49867
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 3.96846 0 3.49867
+      vertex 3.87433 0 3.00524
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 3.87433 0 3.00524
+      vertex 3.71911 0 2.5275
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 3.71911 0 2.5275
+      vertex 3.50523 0 2.07298
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 3.50523 0 2.07298
+      vertex 3.23607 0 1.64886
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 3.23607 0 1.64886
+      vertex 2.91587 0 1.26181
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3.87433 0 4.99476
+      vertex 12 0 0
+      vertex 12 0 12
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 2.5497 0 0.917947
+      vertex 12 0 0
+      vertex 2.91587 0 1.26181
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 2.14331 0 0.622688
+      vertex 12 0 0
+      vertex 2.5497 0 0.917947
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.70312 0 0.380692
+      vertex 12 0 0
+      vertex 2.14331 0 0.622688
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.23607 0 0.195773
+      vertex 12 0 0
+      vertex 1.70312 0 0.380692
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.749525 0 0.0708504
+      vertex 12 0 0
+      vertex 1.23607 0 0.195773
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.251162 0 0.00789261
+      vertex 12 0 0
+      vertex 0.749525 0 0.0708504
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12 0 0
+      vertex 0.251162 0 0.00789261
+      vertex -12 0 0
+    endloop
+  endfacet
+  facet normal -0.904827 0 -0.42578
+    outer loop
+      vertex 3.71911 0 5.4725
+      vertex 3.50523 20 5.92701
+      vertex 3.71911 20 5.4725
+    endloop
+  endfacet
+  facet normal -0.904827 -0 -0.42578
+    outer loop
+      vertex 3.50523 20 5.92701
+      vertex 3.71911 0 5.4725
+      vertex 3.50523 0 5.92701
+    endloop
+  endfacet
+  facet normal 0.368126 0 0.929776
+    outer loop
+      vertex -1.70312 20 0.380692
+      vertex -1.23607 0 0.195773
+      vertex -1.23607 20 0.195773
+    endloop
+  endfacet
+  facet normal 0.368126 0 0.929776
+    outer loop
+      vertex -1.23607 0 0.195773
+      vertex -1.70312 20 0.380692
+      vertex -1.70312 0 0.380692
+    endloop
+  endfacet
+  facet normal -0.368126 0 0.929776
+    outer loop
+      vertex 1.23607 20 0.195773
+      vertex 1.70312 0 0.380692
+      vertex 1.70312 20 0.380692
+    endloop
+  endfacet
+  facet normal -0.368126 0 0.929776
+    outer loop
+      vertex 1.70312 0 0.380692
+      vertex 1.23607 20 0.195773
+      vertex 1.23607 0 0.195773
+    endloop
+  endfacet
+  facet normal -0.587785 0 0.809017
+    outer loop
+      vertex 2.14331 20 0.622688
+      vertex 2.5497 0 0.917947
+      vertex 2.5497 20 0.917947
+    endloop
+  endfacet
+  facet normal -0.587785 0 0.809017
+    outer loop
+      vertex 2.5497 0 0.917947
+      vertex 2.14331 20 0.622688
+      vertex 2.14331 0 0.622688
+    endloop
+  endfacet
+  facet normal -0.24869 0 0.968583
+    outer loop
+      vertex 0.749525 20 0.0708504
+      vertex 1.23607 0 0.195773
+      vertex 1.23607 20 0.195773
+    endloop
+  endfacet
+  facet normal -0.24869 0 0.968583
+    outer loop
+      vertex 1.23607 0 0.195773
+      vertex 0.749525 20 0.0708504
+      vertex 0.749525 0 0.0708504
+    endloop
+  endfacet
+  facet normal -0.951057 0 0.309017
+    outer loop
+      vertex 3.71911 0 2.5275
+      vertex 3.87433 20 3.00524
+      vertex 3.71911 20 2.5275
+    endloop
+  endfacet
+  facet normal -0.951057 0 0.309017
+    outer loop
+      vertex 3.87433 20 3.00524
+      vertex 3.71911 0 2.5275
+      vertex 3.87433 0 3.00524
+    endloop
+  endfacet
+  facet normal -0.844328 0 0.535826
+    outer loop
+      vertex 3.23607 0 1.64886
+      vertex 3.50523 20 2.07298
+      vertex 3.23607 20 1.64886
+    endloop
+  endfacet
+  facet normal -0.844328 0 0.535826
+    outer loop
+      vertex 3.50523 20 2.07298
+      vertex 3.23607 0 1.64886
+      vertex 3.50523 0 2.07298
+    endloop
+  endfacet
+  facet normal -0.904827 0 0.42578
+    outer loop
+      vertex 3.50523 0 2.07298
+      vertex 3.71911 20 2.5275
+      vertex 3.50523 20 2.07298
+    endloop
+  endfacet
+  facet normal -0.904827 0 0.42578
+    outer loop
+      vertex 3.71911 20 2.5275
+      vertex 3.50523 0 2.07298
+      vertex 3.71911 0 2.5275
+    endloop
+  endfacet
+  facet normal -0.998027 0 -0.0627918
+    outer loop
+      vertex 4 0 4
+      vertex 3.96846 20 4.50133
+      vertex 4 20 4
+    endloop
+  endfacet
+  facet normal -0.998027 -0 -0.0627918
+    outer loop
+      vertex 3.96846 20 4.50133
+      vertex 4 0 4
+      vertex 3.96846 0 4.50133
+    endloop
+  endfacet
+  facet normal -0.24869 0 -0.968583
+    outer loop
+      vertex 0.749525 0 7.92915
+      vertex 1.23607 20 7.80423
+      vertex 1.23607 0 7.80423
+    endloop
+  endfacet
+  facet normal -0.24869 0 -0.968583
+    outer loop
+      vertex 1.23607 20 7.80423
+      vertex 0.749525 0 7.92915
+      vertex 0.749525 20 7.92915
+    endloop
+  endfacet
+  facet normal -0.770513 0 -0.637424
+    outer loop
+      vertex 3.23607 0 6.35114
+      vertex 2.91587 20 6.73819
+      vertex 3.23607 20 6.35114
+    endloop
+  endfacet
+  facet normal -0.770513 -0 -0.637424
+    outer loop
+      vertex 2.91587 20 6.73819
+      vertex 3.23607 0 6.35114
+      vertex 2.91587 0 6.73819
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.251162 20 0.00789261
+      vertex 0.251162 0 0.00789261
+      vertex 0.251162 20 0.00789261
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.251162 0 0.00789261
+      vertex -0.251162 20 0.00789261
+      vertex -0.251162 0 0.00789261
+    endloop
+  endfacet
+  facet normal -0.481754 0 0.876307
+    outer loop
+      vertex 1.70312 20 0.380692
+      vertex 2.14331 0 0.622688
+      vertex 2.14331 20 0.622688
+    endloop
+  endfacet
+  facet normal -0.481754 0 0.876307
+    outer loop
+      vertex 2.14331 0 0.622688
+      vertex 1.70312 20 0.380692
+      vertex 1.70312 0 0.380692
+    endloop
+  endfacet
+  facet normal -0.684546 0 0.72897
+    outer loop
+      vertex 2.5497 20 0.917947
+      vertex 2.91587 0 1.26181
+      vertex 2.91587 20 1.26181
+    endloop
+  endfacet
+  facet normal -0.684546 0 0.72897
+    outer loop
+      vertex 2.91587 0 1.26181
+      vertex 2.5497 20 0.917947
+      vertex 2.5497 0 0.917947
+    endloop
+  endfacet
+  facet normal -0.982287 0 0.187381
+    outer loop
+      vertex 3.87433 0 3.00524
+      vertex 3.96846 20 3.49867
+      vertex 3.87433 20 3.00524
+    endloop
+  endfacet
+  facet normal -0.982287 0 0.187381
+    outer loop
+      vertex 3.96846 20 3.49867
+      vertex 3.87433 0 3.00524
+      vertex 3.96846 0 3.49867
+    endloop
+  endfacet
+  facet normal -0.998027 0 0.0627917
+    outer loop
+      vertex 3.96846 0 3.49867
+      vertex 4 20 4
+      vertex 3.96846 20 3.49867
+    endloop
+  endfacet
+  facet normal -0.998027 0 0.0627917
+    outer loop
+      vertex 4 20 4
+      vertex 3.96846 0 3.49867
+      vertex 4 0 4
+    endloop
+  endfacet
+  facet normal 0.998027 2.99414e-09 -0.0627917
+    outer loop
+      vertex -4 20 4
+      vertex -3.96846 0 4.50133
+      vertex -4 0 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.251162 0 7.99211
+      vertex 0.251162 20 7.99211
+      vertex 0.251162 0 7.99211
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 0.251162 20 7.99211
+      vertex -0.251162 0 7.99211
+      vertex -0.251162 20 7.99211
+    endloop
+  endfacet
+  facet normal -0.684546 0 -0.72897
+    outer loop
+      vertex 2.5497 0 7.08205
+      vertex 2.91587 20 6.73819
+      vertex 2.91587 0 6.73819
+    endloop
+  endfacet
+  facet normal -0.684546 0 -0.72897
+    outer loop
+      vertex 2.91587 20 6.73819
+      vertex 2.5497 0 7.08205
+      vertex 2.5497 20 7.08205
+    endloop
+  endfacet
+  facet normal -0.587785 0 -0.809017
+    outer loop
+      vertex 2.14331 0 7.37731
+      vertex 2.5497 20 7.08205
+      vertex 2.5497 0 7.08205
+    endloop
+  endfacet
+  facet normal -0.587785 0 -0.809017
+    outer loop
+      vertex 2.5497 20 7.08205
+      vertex 2.14331 0 7.37731
+      vertex 2.14331 20 7.37731
+    endloop
+  endfacet
+  facet normal -0.368126 0 -0.929776
+    outer loop
+      vertex 1.23607 0 7.80423
+      vertex 1.70312 20 7.61931
+      vertex 1.70312 0 7.61931
+    endloop
+  endfacet
+  facet normal -0.368126 0 -0.929776
+    outer loop
+      vertex 1.70312 20 7.61931
+      vertex 1.23607 0 7.80423
+      vertex 1.23607 20 7.80423
+    endloop
+  endfacet
+  facet normal -0.844328 0 -0.535826
+    outer loop
+      vertex 3.50523 0 5.92701
+      vertex 3.23607 20 6.35114
+      vertex 3.50523 20 5.92701
+    endloop
+  endfacet
+  facet normal -0.844328 -0 -0.535826
+    outer loop
+      vertex 3.23607 20 6.35114
+      vertex 3.50523 0 5.92701
+      vertex 3.23607 0 6.35114
+    endloop
+  endfacet
+  facet normal 0.24869 0 0.968583
+    outer loop
+      vertex -1.23607 20 0.195773
+      vertex -0.749525 0 0.0708504
+      vertex -0.749525 20 0.0708504
+    endloop
+  endfacet
+  facet normal 0.24869 0 0.968583
+    outer loop
+      vertex -0.749525 0 0.0708504
+      vertex -1.23607 20 0.195773
+      vertex -1.23607 0 0.195773
+    endloop
+  endfacet
+  facet normal 0.770513 -0 0.637424
+    outer loop
+      vertex -3.23607 0 1.64886
+      vertex -2.91587 20 1.26181
+      vertex -3.23607 20 1.64886
+    endloop
+  endfacet
+  facet normal 0.770513 0 0.637424
+    outer loop
+      vertex -2.91587 20 1.26181
+      vertex -3.23607 0 1.64886
+      vertex -2.91587 0 1.26181
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.749525 20 7.92915
+      vertex 0.251162 20 7.99211
+      vertex -0.251162 20 7.99211
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.749525 20 7.92915
+      vertex 0.749525 20 7.92915
+      vertex 0.251162 20 7.99211
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.23607 20 7.80423
+      vertex 0.749525 20 7.92915
+      vertex -0.749525 20 7.92915
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.23607 20 7.80423
+      vertex 1.23607 20 7.80423
+      vertex 0.749525 20 7.92915
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.70312 20 7.61931
+      vertex 1.23607 20 7.80423
+      vertex -1.23607 20 7.80423
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.70312 20 7.61931
+      vertex 1.70312 20 7.61931
+      vertex 1.23607 20 7.80423
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.14331 20 7.37731
+      vertex 1.70312 20 7.61931
+      vertex -1.70312 20 7.61931
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.14331 20 7.37731
+      vertex 2.14331 20 7.37731
+      vertex 1.70312 20 7.61931
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5497 20 7.08205
+      vertex 2.14331 20 7.37731
+      vertex -2.14331 20 7.37731
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5497 20 7.08205
+      vertex 2.5497 20 7.08205
+      vertex 2.14331 20 7.37731
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.91587 20 6.73819
+      vertex 2.5497 20 7.08205
+      vertex -2.5497 20 7.08205
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.91587 20 6.73819
+      vertex 2.91587 20 6.73819
+      vertex 2.5497 20 7.08205
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.23607 20 6.35114
+      vertex 2.91587 20 6.73819
+      vertex -2.91587 20 6.73819
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.23607 20 6.35114
+      vertex 3.23607 20 6.35114
+      vertex 2.91587 20 6.73819
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.50523 20 5.92701
+      vertex 3.23607 20 6.35114
+      vertex -3.23607 20 6.35114
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.50523 20 5.92701
+      vertex 3.50523 20 5.92701
+      vertex 3.23607 20 6.35114
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.71911 20 5.4725
+      vertex 3.50523 20 5.92701
+      vertex -3.50523 20 5.92701
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.71911 20 5.4725
+      vertex 3.71911 20 5.4725
+      vertex 3.50523 20 5.92701
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.87433 20 4.99476
+      vertex 3.71911 20 5.4725
+      vertex -3.71911 20 5.4725
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.87433 20 4.99476
+      vertex 3.87433 20 4.99476
+      vertex 3.71911 20 5.4725
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.96846 20 4.50133
+      vertex 3.87433 20 4.99476
+      vertex -3.87433 20 4.99476
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.96846 20 4.50133
+      vertex 3.96846 20 4.50133
+      vertex 3.87433 20 4.99476
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -4 20 4
+      vertex 3.96846 20 4.50133
+      vertex -3.96846 20 4.50133
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -4 20 4
+      vertex 4 20 4
+      vertex 3.96846 20 4.50133
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.96846 20 3.49867
+      vertex 4 20 4
+      vertex -4 20 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.96846 20 3.49867
+      vertex 3.96846 20 3.49867
+      vertex 4 20 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.87433 20 3.00524
+      vertex 3.96846 20 3.49867
+      vertex -3.96846 20 3.49867
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.87433 20 3.00524
+      vertex 3.87433 20 3.00524
+      vertex 3.96846 20 3.49867
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.71911 20 2.5275
+      vertex 3.87433 20 3.00524
+      vertex -3.87433 20 3.00524
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.71911 20 2.5275
+      vertex 3.71911 20 2.5275
+      vertex 3.87433 20 3.00524
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.50523 20 2.07298
+      vertex 3.71911 20 2.5275
+      vertex -3.71911 20 2.5275
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.50523 20 2.07298
+      vertex 3.50523 20 2.07298
+      vertex 3.71911 20 2.5275
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.23607 20 1.64886
+      vertex 3.50523 20 2.07298
+      vertex -3.50523 20 2.07298
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.23607 20 1.64886
+      vertex 3.23607 20 1.64886
+      vertex 3.50523 20 2.07298
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.91587 20 1.26181
+      vertex 3.23607 20 1.64886
+      vertex -3.23607 20 1.64886
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.91587 20 1.26181
+      vertex 2.91587 20 1.26181
+      vertex 3.23607 20 1.64886
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5497 20 0.917947
+      vertex 2.91587 20 1.26181
+      vertex -2.91587 20 1.26181
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5497 20 0.917947
+      vertex 2.5497 20 0.917947
+      vertex 2.91587 20 1.26181
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.14331 20 0.622688
+      vertex 2.5497 20 0.917947
+      vertex -2.5497 20 0.917947
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.14331 20 0.622688
+      vertex 2.14331 20 0.622688
+      vertex 2.5497 20 0.917947
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.70312 20 0.380692
+      vertex 2.14331 20 0.622688
+      vertex -2.14331 20 0.622688
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.70312 20 0.380692
+      vertex 1.70312 20 0.380692
+      vertex 2.14331 20 0.622688
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.23607 20 0.195773
+      vertex 1.70312 20 0.380692
+      vertex -1.70312 20 0.380692
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.23607 20 0.195773
+      vertex 1.23607 20 0.195773
+      vertex 1.70312 20 0.380692
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.749525 20 0.0708504
+      vertex 1.23607 20 0.195773
+      vertex -1.23607 20 0.195773
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.749525 20 0.0708504
+      vertex 0.749525 20 0.0708504
+      vertex 1.23607 20 0.195773
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.251162 20 0.00789261
+      vertex 0.749525 20 0.0708504
+      vertex -0.749525 20 0.0708504
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.749525 20 0.0708504
+      vertex -0.251162 20 0.00789261
+      vertex 0.251162 20 0.00789261
+    endloop
+  endfacet
+  facet normal -0.125333 0 0.992115
+    outer loop
+      vertex 0.251162 20 0.00789261
+      vertex 0.749525 0 0.0708504
+      vertex 0.749525 20 0.0708504
+    endloop
+  endfacet
+  facet normal -0.125333 0 0.992115
+    outer loop
+      vertex 0.749525 0 0.0708504
+      vertex 0.251162 20 0.00789261
+      vertex 0.251162 0 0.00789261
+    endloop
+  endfacet
+  facet normal -0.770513 0 0.637424
+    outer loop
+      vertex 2.91587 0 1.26181
+      vertex 3.23607 20 1.64886
+      vertex 2.91587 20 1.26181
+    endloop
+  endfacet
+  facet normal -0.770513 0 0.637424
+    outer loop
+      vertex 3.23607 20 1.64886
+      vertex 2.91587 0 1.26181
+      vertex 3.23607 0 1.64886
+    endloop
+  endfacet
+  facet normal 0.770513 0 -0.637424
+    outer loop
+      vertex -2.91587 0 6.73819
+      vertex -3.23607 20 6.35114
+      vertex -2.91587 20 6.73819
+    endloop
+  endfacet
+  facet normal 0.770513 0 -0.637424
+    outer loop
+      vertex -3.23607 20 6.35114
+      vertex -2.91587 0 6.73819
+      vertex -3.23607 0 6.35114
+    endloop
+  endfacet
+  facet normal 0.951057 0 -0.309017
+    outer loop
+      vertex -3.71911 0 5.4725
+      vertex -3.87433 20 4.99476
+      vertex -3.71911 20 5.4725
+    endloop
+  endfacet
+  facet normal 0.951057 0 -0.309017
+    outer loop
+      vertex -3.87433 20 4.99476
+      vertex -3.71911 0 5.4725
+      vertex -3.87433 0 4.99476
+    endloop
+  endfacet
+  facet normal 0.998027 0 -0.0627918
+    outer loop
+      vertex -3.96846 20 4.50133
+      vertex -3.96846 0 4.50133
+      vertex -4 20 4
+    endloop
+  endfacet
+  facet normal 0.481754 0 -0.876307
+    outer loop
+      vertex -2.14331 0 7.37731
+      vertex -1.70312 20 7.61931
+      vertex -1.70312 0 7.61931
+    endloop
+  endfacet
+  facet normal 0.481754 0 -0.876307
+    outer loop
+      vertex -1.70312 20 7.61931
+      vertex -2.14331 0 7.37731
+      vertex -2.14331 20 7.37731
+    endloop
+  endfacet
+  facet normal 0.125333 0 -0.992115
+    outer loop
+      vertex -0.749525 0 7.92915
+      vertex -0.251162 20 7.99211
+      vertex -0.251162 0 7.99211
+    endloop
+  endfacet
+  facet normal 0.125333 0 -0.992115
+    outer loop
+      vertex -0.251162 20 7.99211
+      vertex -0.749525 0 7.92915
+      vertex -0.749525 20 7.92915
+    endloop
+  endfacet
+  facet normal 0.368126 0 -0.929776
+    outer loop
+      vertex -1.70312 0 7.61931
+      vertex -1.23607 20 7.80423
+      vertex -1.23607 0 7.80423
+    endloop
+  endfacet
+  facet normal 0.368126 0 -0.929776
+    outer loop
+      vertex -1.23607 20 7.80423
+      vertex -1.70312 0 7.61931
+      vertex -1.70312 20 7.61931
+    endloop
+  endfacet
+  facet normal 0.24869 0 -0.968583
+    outer loop
+      vertex -1.23607 0 7.80423
+      vertex -0.749525 20 7.92915
+      vertex -0.749525 0 7.92915
+    endloop
+  endfacet
+  facet normal 0.24869 0 -0.968583
+    outer loop
+      vertex -0.749525 20 7.92915
+      vertex -1.23607 0 7.80423
+      vertex -1.23607 20 7.80423
+    endloop
+  endfacet
+  facet normal -0.982287 0 -0.187381
+    outer loop
+      vertex 3.96846 0 4.50133
+      vertex 3.87433 20 4.99476
+      vertex 3.96846 20 4.50133
+    endloop
+  endfacet
+  facet normal -0.982287 -0 -0.187381
+    outer loop
+      vertex 3.87433 20 4.99476
+      vertex 3.96846 0 4.50133
+      vertex 3.87433 0 4.99476
+    endloop
+  endfacet
+  facet normal -0.951057 0 -0.309017
+    outer loop
+      vertex 3.87433 0 4.99476
+      vertex 3.71911 20 5.4725
+      vertex 3.87433 20 4.99476
+    endloop
+  endfacet
+  facet normal -0.951057 -0 -0.309017
+    outer loop
+      vertex 3.71911 20 5.4725
+      vertex 3.87433 0 4.99476
+      vertex 3.71911 0 5.4725
+    endloop
+  endfacet
+  facet normal -0.125333 0 -0.992115
+    outer loop
+      vertex 0.251162 0 7.99211
+      vertex 0.749525 20 7.92915
+      vertex 0.749525 0 7.92915
+    endloop
+  endfacet
+  facet normal -0.125333 0 -0.992115
+    outer loop
+      vertex 0.749525 20 7.92915
+      vertex 0.251162 0 7.99211
+      vertex 0.251162 20 7.99211
+    endloop
+  endfacet
+  facet normal -0.481754 0 -0.876307
+    outer loop
+      vertex 1.70312 0 7.61931
+      vertex 2.14331 20 7.37731
+      vertex 2.14331 0 7.37731
+    endloop
+  endfacet
+  facet normal -0.481754 0 -0.876307
+    outer loop
+      vertex 2.14331 20 7.37731
+      vertex 1.70312 0 7.61931
+      vertex 1.70312 20 7.61931
+    endloop
+  endfacet
+  facet normal 0.125333 0 0.992115
+    outer loop
+      vertex -0.749525 20 0.0708504
+      vertex -0.251162 0 0.00789261
+      vertex -0.251162 20 0.00789261
+    endloop
+  endfacet
+  facet normal 0.125333 0 0.992115
+    outer loop
+      vertex -0.251162 0 0.00789261
+      vertex -0.749525 20 0.0708504
+      vertex -0.749525 0 0.0708504
+    endloop
+  endfacet
+  facet normal 0.684546 0 0.72897
+    outer loop
+      vertex -2.91587 20 1.26181
+      vertex -2.5497 0 0.917947
+      vertex -2.5497 20 0.917947
+    endloop
+  endfacet
+  facet normal 0.684546 0 0.72897
+    outer loop
+      vertex -2.5497 0 0.917947
+      vertex -2.91587 20 1.26181
+      vertex -2.91587 0 1.26181
+    endloop
+  endfacet
+  facet normal 0.844328 -0 0.535826
+    outer loop
+      vertex -3.50523 0 2.07298
+      vertex -3.23607 20 1.64886
+      vertex -3.50523 20 2.07298
+    endloop
+  endfacet
+  facet normal 0.844328 0 0.535826
+    outer loop
+      vertex -3.23607 20 1.64886
+      vertex -3.50523 0 2.07298
+      vertex -3.23607 0 1.64886
+    endloop
+  endfacet
+  facet normal 0.998027 -2.99414e-09 0.0627917
+    outer loop
+      vertex -3.96846 20 3.49867
+      vertex -4 20 4
+      vertex -4 0 4
+    endloop
+  endfacet
+  facet normal 0.982287 0 -0.187381
+    outer loop
+      vertex -3.87433 0 4.99476
+      vertex -3.96846 20 4.50133
+      vertex -3.87433 20 4.99476
+    endloop
+  endfacet
+  facet normal 0.982287 0 -0.187381
+    outer loop
+      vertex -3.96846 20 4.50133
+      vertex -3.87433 0 4.99476
+      vertex -3.96846 0 4.50133
+    endloop
+  endfacet
+  facet normal 0.587785 0 0.809017
+    outer loop
+      vertex -2.5497 20 0.917947
+      vertex -2.14331 0 0.622688
+      vertex -2.14331 20 0.622688
+    endloop
+  endfacet
+  facet normal 0.587785 0 0.809017
+    outer loop
+      vertex -2.14331 0 0.622688
+      vertex -2.5497 20 0.917947
+      vertex -2.5497 0 0.917947
+    endloop
+  endfacet
+  facet normal 0.481754 0 0.876307
+    outer loop
+      vertex -2.14331 20 0.622688
+      vertex -1.70312 0 0.380692
+      vertex -1.70312 20 0.380692
+    endloop
+  endfacet
+  facet normal 0.481754 0 0.876307
+    outer loop
+      vertex -1.70312 0 0.380692
+      vertex -2.14331 20 0.622688
+      vertex -2.14331 0 0.622688
+    endloop
+  endfacet
+  facet normal 0.904827 -0 0.42578
+    outer loop
+      vertex -3.71911 0 2.5275
+      vertex -3.50523 20 2.07298
+      vertex -3.71911 20 2.5275
+    endloop
+  endfacet
+  facet normal 0.904827 0 0.42578
+    outer loop
+      vertex -3.50523 20 2.07298
+      vertex -3.71911 0 2.5275
+      vertex -3.50523 0 2.07298
+    endloop
+  endfacet
+  facet normal 0.951057 -0 0.309017
+    outer loop
+      vertex -3.87433 0 3.00524
+      vertex -3.71911 20 2.5275
+      vertex -3.87433 20 3.00524
+    endloop
+  endfacet
+  facet normal 0.951057 0 0.309017
+    outer loop
+      vertex -3.71911 20 2.5275
+      vertex -3.87433 0 3.00524
+      vertex -3.71911 0 2.5275
+    endloop
+  endfacet
+  facet normal 0.844328 0 -0.535826
+    outer loop
+      vertex -3.23607 0 6.35114
+      vertex -3.50523 20 5.92701
+      vertex -3.23607 20 6.35114
+    endloop
+  endfacet
+  facet normal 0.844328 0 -0.535826
+    outer loop
+      vertex -3.50523 20 5.92701
+      vertex -3.23607 0 6.35114
+      vertex -3.50523 0 5.92701
+    endloop
+  endfacet
+  facet normal 0.904827 0 -0.42578
+    outer loop
+      vertex -3.50523 0 5.92701
+      vertex -3.71911 20 5.4725
+      vertex -3.50523 20 5.92701
+    endloop
+  endfacet
+  facet normal 0.904827 0 -0.42578
+    outer loop
+      vertex -3.71911 20 5.4725
+      vertex -3.50523 0 5.92701
+      vertex -3.71911 0 5.4725
+    endloop
+  endfacet
+  facet normal 0.684546 0 -0.72897
+    outer loop
+      vertex -2.91587 0 6.73819
+      vertex -2.5497 20 7.08205
+      vertex -2.5497 0 7.08205
+    endloop
+  endfacet
+  facet normal 0.684546 0 -0.72897
+    outer loop
+      vertex -2.5497 20 7.08205
+      vertex -2.91587 0 6.73819
+      vertex -2.91587 20 6.73819
+    endloop
+  endfacet
+  facet normal 0.998027 -0 0.0627918
+    outer loop
+      vertex -3.96846 0 3.49867
+      vertex -3.96846 20 3.49867
+      vertex -4 0 4
+    endloop
+  endfacet
+  facet normal 0.982287 -0 0.187381
+    outer loop
+      vertex -3.96846 0 3.49867
+      vertex -3.87433 20 3.00524
+      vertex -3.96846 20 3.49867
+    endloop
+  endfacet
+  facet normal 0.982287 0 0.187381
+    outer loop
+      vertex -3.87433 20 3.00524
+      vertex -3.96846 0 3.49867
+      vertex -3.87433 0 3.00524
+    endloop
+  endfacet
+  facet normal 0.587785 0 -0.809017
+    outer loop
+      vertex -2.5497 0 7.08205
+      vertex -2.14331 20 7.37731
+      vertex -2.14331 0 7.37731
+    endloop
+  endfacet
+  facet normal 0.587785 0 -0.809017
+    outer loop
+      vertex -2.14331 20 7.37731
+      vertex -2.5497 0 7.08205
+      vertex -2.5497 20 7.08205
+    endloop
+  endfacet
+  facet normal -0.844326 -0.535829 0
+    outer loop
+      vertex 9.31446 10.7226 0
+      vertex 9.21352 10.8817 12
+      vertex 9.21352 10.8817 0
+    endloop
+  endfacet
+  facet normal -0.844326 -0.535829 0
+    outer loop
+      vertex 9.21352 10.8817 12
+      vertex 9.31446 10.7226 0
+      vertex 9.31446 10.7226 12
+    endloop
+  endfacet
+  facet normal -0.248692 -0.968583 0
+    outer loop
+      vertex 8.28107 11.4734 0
+      vertex 8.46352 11.4266 12
+      vertex 8.28107 11.4734 12
+    endloop
+  endfacet
+  facet normal -0.248692 -0.968583 -0
+    outer loop
+      vertex 8.46352 11.4266 12
+      vertex 8.28107 11.4734 0
+      vertex 8.46352 11.4266 0
+    endloop
+  endfacet
+  facet normal 0.481754 -0.876307 0
+    outer loop
+      vertex 7.19626 11.2665 0
+      vertex 7.36133 11.3572 12
+      vertex 7.19626 11.2665 12
+    endloop
+  endfacet
+  facet normal 0.481754 -0.876307 0
+    outer loop
+      vertex 7.36133 11.3572 12
+      vertex 7.19626 11.2665 0
+      vertex 7.36133 11.3572 0
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309019 0
+    outer loop
+      vertex 6.54712 10.373 12
+      vertex 6.60534 10.5522 0
+      vertex 6.60534 10.5522 12
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309019 0
+    outer loop
+      vertex 6.60534 10.5522 0
+      vertex 6.54712 10.373 12
+      vertex 6.54712 10.373 0
+    endloop
+  endfacet
+  facet normal -0.982287 0.187382 0
+    outer loop
+      vertex 9.45287 9.62696 0
+      vertex 9.48817 9.812 12
+      vertex 9.48817 9.812 0
+    endloop
+  endfacet
+  facet normal -0.982287 0.187382 0
+    outer loop
+      vertex 9.48817 9.812 12
+      vertex 9.45287 9.62696 0
+      vertex 9.45287 9.62696 12
+    endloop
+  endfacet
+  facet normal -0.982287 -0.187382 0
+    outer loop
+      vertex 9.48817 10.188 0
+      vertex 9.45287 10.373 12
+      vertex 9.45287 10.373 0
+    endloop
+  endfacet
+  facet normal -0.982287 -0.187382 0
+    outer loop
+      vertex 9.45287 10.373 12
+      vertex 9.48817 10.188 0
+      vertex 9.48817 10.188 12
+    endloop
+  endfacet
+  facet normal -0.684548 -0.728968 0
+    outer loop
+      vertex 8.95614 11.1558 0
+      vertex 9.09345 11.0268 12
+      vertex 8.95614 11.1558 12
+    endloop
+  endfacet
+  facet normal -0.684548 -0.728968 -0
+    outer loop
+      vertex 9.09345 11.0268 12
+      vertex 8.95614 11.1558 0
+      vertex 9.09345 11.0268 0
+    endloop
+  endfacet
+  facet normal -0.481754 -0.876307 0
+    outer loop
+      vertex 8.63867 11.3572 0
+      vertex 8.80374 11.2665 12
+      vertex 8.63867 11.3572 12
+    endloop
+  endfacet
+  facet normal -0.481754 -0.876307 -0
+    outer loop
+      vertex 8.80374 11.2665 12
+      vertex 8.63867 11.3572 0
+      vertex 8.80374 11.2665 0
+    endloop
+  endfacet
+  facet normal 0.998027 -0.062788 0
+    outer loop
+      vertex 6.5 10 12
+      vertex 6.51183 10.188 0
+      vertex 6.51183 10.188 12
+    endloop
+  endfacet
+  facet normal 0.998027 -0.062788 0
+    outer loop
+      vertex 6.51183 10.188 0
+      vertex 6.5 10 12
+      vertex 6.5 10 0
+    endloop
+  endfacet
+  facet normal 0.844326 -0.535829 0
+    outer loop
+      vertex 6.68554 10.7226 12
+      vertex 6.78647 10.8817 0
+      vertex 6.78647 10.8817 12
+    endloop
+  endfacet
+  facet normal 0.844326 -0.535829 0
+    outer loop
+      vertex 6.78647 10.8817 0
+      vertex 6.68554 10.7226 12
+      vertex 6.68554 10.7226 0
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex 7.04386 11.1558 0
+      vertex 7.19626 11.2665 12
+      vertex 7.04386 11.1558 12
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex 7.19626 11.2665 12
+      vertex 7.04386 11.1558 0
+      vertex 7.19626 11.2665 0
+    endloop
+  endfacet
+  facet normal 0.248692 -0.968583 0
+    outer loop
+      vertex 7.53647 11.4266 0
+      vertex 7.71893 11.4734 12
+      vertex 7.53647 11.4266 12
+    endloop
+  endfacet
+  facet normal 0.248692 -0.968583 0
+    outer loop
+      vertex 7.71893 11.4734 12
+      vertex 7.53647 11.4266 0
+      vertex 7.71893 11.4734 0
+    endloop
+  endfacet
+  facet normal -0.998027 -0.0627931 0
+    outer loop
+      vertex 9.5 10 0
+      vertex 9.48817 10.188 12
+      vertex 9.48817 10.188 0
+    endloop
+  endfacet
+  facet normal -0.998027 -0.0627931 0
+    outer loop
+      vertex 9.48817 10.188 12
+      vertex 9.5 10 0
+      vertex 9.5 10 12
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex 8.95614 8.84423 0
+      vertex 8.80374 8.73351 12
+      vertex 8.95614 8.84423 12
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex 8.80374 8.73351 12
+      vertex 8.95614 8.84423 0
+      vertex 8.80374 8.73351 0
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 -0
+    outer loop
+      vertex 7.19626 8.73351 0
+      vertex 7.04386 8.84423 12
+      vertex 7.19626 8.73351 12
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 0
+    outer loop
+      vertex 7.04386 8.84423 12
+      vertex 7.19626 8.73351 0
+      vertex 7.04386 8.84423 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 9.21352 10.8817 0
+      vertex 9.09345 11.0268 12
+      vertex 9.09345 11.0268 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex 9.09345 11.0268 12
+      vertex 9.21352 10.8817 0
+      vertex 9.21352 10.8817 12
+    endloop
+  endfacet
+  facet normal 0.125333 -0.992115 0
+    outer loop
+      vertex 7.71893 11.4734 0
+      vertex 7.90581 11.497 12
+      vertex 7.71893 11.4734 12
+    endloop
+  endfacet
+  facet normal 0.125333 -0.992115 0
+    outer loop
+      vertex 7.90581 11.497 12
+      vertex 7.71893 11.4734 0
+      vertex 7.90581 11.497 0
+    endloop
+  endfacet
+  facet normal -0.125333 -0.992115 0
+    outer loop
+      vertex 8.09418 11.497 0
+      vertex 8.28107 11.4734 12
+      vertex 8.09418 11.497 12
+    endloop
+  endfacet
+  facet normal -0.125333 -0.992115 -0
+    outer loop
+      vertex 8.28107 11.4734 12
+      vertex 8.09418 11.497 0
+      vertex 8.28107 11.4734 0
+    endloop
+  endfacet
+  facet normal -0.368126 -0.929776 0
+    outer loop
+      vertex 8.46352 11.4266 0
+      vertex 8.63867 11.3572 12
+      vertex 8.46352 11.4266 12
+    endloop
+  endfacet
+  facet normal -0.368126 -0.929776 -0
+    outer loop
+      vertex 8.63867 11.3572 12
+      vertex 8.46352 11.4266 0
+      vertex 8.63867 11.3572 0
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 0
+    outer loop
+      vertex 8.80374 11.2665 0
+      vertex 8.95614 11.1558 12
+      vertex 8.80374 11.2665 12
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 -0
+    outer loop
+      vertex 8.95614 11.1558 12
+      vertex 8.80374 11.2665 0
+      vertex 8.95614 11.1558 0
+    endloop
+  endfacet
+  facet normal 0.998027 0.0627877 0
+    outer loop
+      vertex 6.51183 9.812 12
+      vertex 6.5 10 0
+      vertex 6.5 10 12
+    endloop
+  endfacet
+  facet normal 0.998027 0.0627877 0
+    outer loop
+      vertex 6.5 10 0
+      vertex 6.51183 9.812 12
+      vertex 6.51183 9.812 0
+    endloop
+  endfacet
+  facet normal 0.982287 -0.187382 0
+    outer loop
+      vertex 6.51183 10.188 12
+      vertex 6.54712 10.373 0
+      vertex 6.54712 10.373 12
+    endloop
+  endfacet
+  facet normal 0.982287 -0.187382 0
+    outer loop
+      vertex 6.54712 10.373 0
+      vertex 6.51183 10.188 12
+      vertex 6.51183 10.188 0
+    endloop
+  endfacet
+  facet normal 0.904829 -0.425775 0
+    outer loop
+      vertex 6.60534 10.5522 12
+      vertex 6.68554 10.7226 0
+      vertex 6.68554 10.7226 12
+    endloop
+  endfacet
+  facet normal 0.904829 -0.425775 0
+    outer loop
+      vertex 6.68554 10.7226 0
+      vertex 6.60534 10.5522 12
+      vertex 6.60534 10.5522 0
+    endloop
+  endfacet
+  facet normal 0.368126 -0.929776 0
+    outer loop
+      vertex 7.36133 11.3572 0
+      vertex 7.53647 11.4266 12
+      vertex 7.36133 11.3572 12
+    endloop
+  endfacet
+  facet normal 0.368126 -0.929776 0
+    outer loop
+      vertex 7.53647 11.4266 12
+      vertex 7.36133 11.3572 0
+      vertex 7.53647 11.4266 0
+    endloop
+  endfacet
+  facet normal 0.684548 -0.728968 0
+    outer loop
+      vertex 6.90655 11.0268 0
+      vertex 7.04386 11.1558 12
+      vertex 6.90655 11.0268 12
+    endloop
+  endfacet
+  facet normal 0.684548 -0.728968 0
+    outer loop
+      vertex 7.04386 11.1558 12
+      vertex 6.90655 11.0268 0
+      vertex 7.04386 11.1558 0
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 6.78647 10.8817 12
+      vertex 6.90655 11.0268 0
+      vertex 6.90655 11.0268 12
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex 6.90655 11.0268 0
+      vertex 6.78647 10.8817 12
+      vertex 6.78647 10.8817 0
+    endloop
+  endfacet
+  facet normal -0.125333 0.992115 0
+    outer loop
+      vertex 8.28107 8.52657 0
+      vertex 8.09418 8.50296 12
+      vertex 8.28107 8.52657 12
+    endloop
+  endfacet
+  facet normal -0.125333 0.992115 0
+    outer loop
+      vertex 8.09418 8.50296 12
+      vertex 8.28107 8.52657 0
+      vertex 8.09418 8.50296 0
+    endloop
+  endfacet
+  facet normal 0.982287 0.187382 0
+    outer loop
+      vertex 6.54712 9.62696 12
+      vertex 6.51183 9.812 0
+      vertex 6.51183 9.812 12
+    endloop
+  endfacet
+  facet normal 0.982287 0.187382 0
+    outer loop
+      vertex 6.51183 9.812 0
+      vertex 6.54712 9.62696 12
+      vertex 6.54712 9.62696 0
+    endloop
+  endfacet
+  facet normal 0.684548 0.728968 -0
+    outer loop
+      vertex 7.04386 8.84423 0
+      vertex 6.90655 8.97318 12
+      vertex 7.04386 8.84423 12
+    endloop
+  endfacet
+  facet normal 0.684548 0.728968 0
+    outer loop
+      vertex 6.90655 8.97318 12
+      vertex 7.04386 8.84423 0
+      vertex 6.90655 8.97318 0
+    endloop
+  endfacet
+  facet normal -0.248692 0.968583 0
+    outer loop
+      vertex 8.46352 8.57341 0
+      vertex 8.28107 8.52657 12
+      vertex 8.46352 8.57341 12
+    endloop
+  endfacet
+  facet normal -0.248692 0.968583 0
+    outer loop
+      vertex 8.28107 8.52657 12
+      vertex 8.46352 8.57341 0
+      vertex 8.28107 8.52657 0
+    endloop
+  endfacet
+  facet normal -0.904829 -0.425775 0
+    outer loop
+      vertex 9.39466 10.5522 0
+      vertex 9.31446 10.7226 12
+      vertex 9.31446 10.7226 0
+    endloop
+  endfacet
+  facet normal -0.904829 -0.425775 0
+    outer loop
+      vertex 9.31446 10.7226 12
+      vertex 9.39466 10.5522 0
+      vertex 9.39466 10.5522 12
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309019 0
+    outer loop
+      vertex 9.45287 10.373 0
+      vertex 9.39466 10.5522 12
+      vertex 9.39466 10.5522 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309019 0
+    outer loop
+      vertex 9.39466 10.5522 12
+      vertex 9.45287 10.373 0
+      vertex 9.45287 10.373 12
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 7.90581 11.497 0
+      vertex 8.09418 11.497 12
+      vertex 7.90581 11.497 12
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 8.09418 11.497 12
+      vertex 7.90581 11.497 0
+      vertex 8.09418 11.497 0
+    endloop
+  endfacet
+  facet normal -0.998027 0.0627928 0
+    outer loop
+      vertex 9.48817 9.812 0
+      vertex 9.5 10 12
+      vertex 9.5 10 0
+    endloop
+  endfacet
+  facet normal -0.998027 0.0627928 0
+    outer loop
+      vertex 9.5 10 12
+      vertex 9.48817 9.812 0
+      vertex 9.48817 9.812 12
+    endloop
+  endfacet
+  facet normal -0.904829 0.425775 0
+    outer loop
+      vertex 9.31446 9.27737 0
+      vertex 9.39466 9.44781 12
+      vertex 9.39466 9.44781 0
+    endloop
+  endfacet
+  facet normal -0.904829 0.425775 0
+    outer loop
+      vertex 9.39466 9.44781 12
+      vertex 9.31446 9.27737 0
+      vertex 9.31446 9.27737 12
+    endloop
+  endfacet
+  facet normal -0.951056 0.309019 0
+    outer loop
+      vertex 9.39466 9.44781 0
+      vertex 9.45287 9.62696 12
+      vertex 9.45287 9.62696 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309019 0
+    outer loop
+      vertex 9.45287 9.62696 12
+      vertex 9.39466 9.44781 0
+      vertex 9.39466 9.44781 12
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 9.09345 8.97318 0
+      vertex 9.21352 9.11832 12
+      vertex 9.21352 9.11832 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex 9.21352 9.11832 12
+      vertex 9.09345 8.97318 0
+      vertex 9.09345 8.97318 12
+    endloop
+  endfacet
+  facet normal -0.844326 0.535829 0
+    outer loop
+      vertex 9.21352 9.11832 0
+      vertex 9.31446 9.27737 12
+      vertex 9.31446 9.27737 0
+    endloop
+  endfacet
+  facet normal -0.844326 0.535829 0
+    outer loop
+      vertex 9.31446 9.27737 12
+      vertex 9.21352 9.11832 0
+      vertex 9.21352 9.11832 12
+    endloop
+  endfacet
+  facet normal 0.248692 0.968583 -0
+    outer loop
+      vertex 7.71893 8.52657 0
+      vertex 7.53647 8.57341 12
+      vertex 7.71893 8.52657 12
+    endloop
+  endfacet
+  facet normal 0.248692 0.968583 0
+    outer loop
+      vertex 7.53647 8.57341 12
+      vertex 7.71893 8.52657 0
+      vertex 7.53647 8.57341 0
+    endloop
+  endfacet
+  facet normal 0.125333 0.992115 -0
+    outer loop
+      vertex 7.90581 8.50296 0
+      vertex 7.71893 8.52657 12
+      vertex 7.90581 8.50296 12
+    endloop
+  endfacet
+  facet normal 0.125333 0.992115 0
+    outer loop
+      vertex 7.71893 8.52657 12
+      vertex 7.90581 8.50296 0
+      vertex 7.71893 8.52657 0
+    endloop
+  endfacet
+  facet normal 0.904829 0.425775 0
+    outer loop
+      vertex 6.68554 9.27737 12
+      vertex 6.60534 9.44781 0
+      vertex 6.60534 9.44781 12
+    endloop
+  endfacet
+  facet normal 0.904829 0.425775 0
+    outer loop
+      vertex 6.60534 9.44781 0
+      vertex 6.68554 9.27737 12
+      vertex 6.68554 9.27737 0
+    endloop
+  endfacet
+  facet normal 0.951056 0.309019 0
+    outer loop
+      vertex 6.60534 9.44781 12
+      vertex 6.54712 9.62696 0
+      vertex 6.54712 9.62696 12
+    endloop
+  endfacet
+  facet normal 0.951056 0.309019 0
+    outer loop
+      vertex 6.54712 9.62696 0
+      vertex 6.60534 9.44781 12
+      vertex 6.60534 9.44781 0
+    endloop
+  endfacet
+  facet normal -0.481754 0.876307 0
+    outer loop
+      vertex 8.80374 8.73351 0
+      vertex 8.63867 8.64276 12
+      vertex 8.80374 8.73351 12
+    endloop
+  endfacet
+  facet normal -0.481754 0.876307 0
+    outer loop
+      vertex 8.63867 8.64276 12
+      vertex 8.80374 8.73351 0
+      vertex 8.63867 8.64276 0
+    endloop
+  endfacet
+  facet normal -0.368126 0.929776 0
+    outer loop
+      vertex 8.63867 8.64276 0
+      vertex 8.46352 8.57341 12
+      vertex 8.63867 8.64276 12
+    endloop
+  endfacet
+  facet normal -0.368126 0.929776 0
+    outer loop
+      vertex 8.46352 8.57341 12
+      vertex 8.63867 8.64276 0
+      vertex 8.46352 8.57341 0
+    endloop
+  endfacet
+  facet normal -0.684548 0.728968 0
+    outer loop
+      vertex 9.09345 8.97318 0
+      vertex 8.95614 8.84423 12
+      vertex 9.09345 8.97318 12
+    endloop
+  endfacet
+  facet normal -0.684548 0.728968 0
+    outer loop
+      vertex 8.95614 8.84423 12
+      vertex 9.09345 8.97318 0
+      vertex 8.95614 8.84423 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 8.09418 8.50296 0
+      vertex 7.90581 8.50296 12
+      vertex 8.09418 8.50296 12
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 7.90581 8.50296 12
+      vertex 8.09418 8.50296 0
+      vertex 7.90581 8.50296 0
+    endloop
+  endfacet
+  facet normal 0.368126 0.929776 -0
+    outer loop
+      vertex 7.53647 8.57341 0
+      vertex 7.36133 8.64276 12
+      vertex 7.53647 8.57341 12
+    endloop
+  endfacet
+  facet normal 0.368126 0.929776 0
+    outer loop
+      vertex 7.36133 8.64276 12
+      vertex 7.53647 8.57341 0
+      vertex 7.36133 8.64276 0
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 6.90655 8.97318 12
+      vertex 6.78647 9.11832 0
+      vertex 6.78647 9.11832 12
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex 6.78647 9.11832 0
+      vertex 6.90655 8.97318 12
+      vertex 6.90655 8.97318 0
+    endloop
+  endfacet
+  facet normal 0.844326 0.535829 0
+    outer loop
+      vertex 6.78647 9.11832 12
+      vertex 6.68554 9.27737 0
+      vertex 6.68554 9.27737 12
+    endloop
+  endfacet
+  facet normal 0.844326 0.535829 0
+    outer loop
+      vertex 6.68554 9.27737 0
+      vertex 6.78647 9.11832 12
+      vertex 6.78647 9.11832 0
+    endloop
+  endfacet
+  facet normal 0.481754 0.876307 -0
+    outer loop
+      vertex 7.36133 8.64276 0
+      vertex 7.19626 8.73351 12
+      vertex 7.36133 8.64276 12
+    endloop
+  endfacet
+  facet normal 0.481754 0.876307 0
+    outer loop
+      vertex 7.19626 8.73351 12
+      vertex 7.36133 8.64276 0
+      vertex 7.19626 8.73351 0
+    endloop
+  endfacet
+  facet normal -0.998027 -0.062788 0
+    outer loop
+      vertex -6.5 10 0
+      vertex -6.51183 10.188 12
+      vertex -6.51183 10.188 0
+    endloop
+  endfacet
+  facet normal -0.998027 -0.062788 0
+    outer loop
+      vertex -6.51183 10.188 12
+      vertex -6.5 10 0
+      vertex -6.5 10 12
+    endloop
+  endfacet
+  facet normal 0.998027 -0.0627931 0
+    outer loop
+      vertex -9.5 10 12
+      vertex -9.48817 10.188 0
+      vertex -9.48817 10.188 12
+    endloop
+  endfacet
+  facet normal 0.998027 -0.0627931 0
+    outer loop
+      vertex -9.48817 10.188 0
+      vertex -9.5 10 12
+      vertex -9.5 10 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.09418 11.497 0
+      vertex -7.90581 11.497 12
+      vertex -8.09418 11.497 12
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -7.90581 11.497 12
+      vertex -8.09418 11.497 0
+      vertex -7.90581 11.497 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -7.90581 8.50296 0
+      vertex -8.09418 8.50296 12
+      vertex -7.90581 8.50296 12
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -8.09418 8.50296 12
+      vertex -7.90581 8.50296 0
+      vertex -8.09418 8.50296 0
+    endloop
+  endfacet
+  facet normal -0.684548 -0.728968 0
+    outer loop
+      vertex -7.04386 11.1558 0
+      vertex -6.90655 11.0268 12
+      vertex -7.04386 11.1558 12
+    endloop
+  endfacet
+  facet normal -0.684548 -0.728968 -0
+    outer loop
+      vertex -6.90655 11.0268 12
+      vertex -7.04386 11.1558 0
+      vertex -6.90655 11.0268 0
+    endloop
+  endfacet
+  facet normal 0.684548 -0.728968 0
+    outer loop
+      vertex -9.09345 11.0268 0
+      vertex -8.95614 11.1558 12
+      vertex -9.09345 11.0268 12
+    endloop
+  endfacet
+  facet normal 0.684548 -0.728968 0
+    outer loop
+      vertex -8.95614 11.1558 12
+      vertex -9.09345 11.0268 0
+      vertex -8.95614 11.1558 0
+    endloop
+  endfacet
+  facet normal 0.368126 -0.929776 0
+    outer loop
+      vertex -8.63867 11.3572 0
+      vertex -8.46352 11.4266 12
+      vertex -8.63867 11.3572 12
+    endloop
+  endfacet
+  facet normal 0.368126 -0.929776 0
+    outer loop
+      vertex -8.46352 11.4266 12
+      vertex -8.63867 11.3572 0
+      vertex -8.46352 11.4266 0
+    endloop
+  endfacet
+  facet normal -0.844326 0.535829 0
+    outer loop
+      vertex -6.78647 9.11832 0
+      vertex -6.68554 9.27737 12
+      vertex -6.68554 9.27737 0
+    endloop
+  endfacet
+  facet normal -0.844326 0.535829 0
+    outer loop
+      vertex -6.68554 9.27737 12
+      vertex -6.78647 9.11832 0
+      vertex -6.78647 9.11832 12
+    endloop
+  endfacet
+  facet normal -0.904829 -0.425775 0
+    outer loop
+      vertex -6.60534 10.5522 0
+      vertex -6.68554 10.7226 12
+      vertex -6.68554 10.7226 0
+    endloop
+  endfacet
+  facet normal -0.904829 -0.425775 0
+    outer loop
+      vertex -6.68554 10.7226 12
+      vertex -6.60534 10.5522 0
+      vertex -6.60534 10.5522 12
+    endloop
+  endfacet
+  facet normal -0.982287 -0.187382 0
+    outer loop
+      vertex -6.51183 10.188 0
+      vertex -6.54712 10.373 12
+      vertex -6.54712 10.373 0
+    endloop
+  endfacet
+  facet normal -0.982287 -0.187382 0
+    outer loop
+      vertex -6.54712 10.373 12
+      vertex -6.51183 10.188 0
+      vertex -6.51183 10.188 12
+    endloop
+  endfacet
+  facet normal -0.368126 -0.929776 0
+    outer loop
+      vertex -7.53647 11.4266 0
+      vertex -7.36133 11.3572 12
+      vertex -7.53647 11.4266 12
+    endloop
+  endfacet
+  facet normal -0.368126 -0.929776 -0
+    outer loop
+      vertex -7.36133 11.3572 12
+      vertex -7.53647 11.4266 0
+      vertex -7.36133 11.3572 0
+    endloop
+  endfacet
+  facet normal -0.248692 -0.968583 0
+    outer loop
+      vertex -7.71893 11.4734 0
+      vertex -7.53647 11.4266 12
+      vertex -7.71893 11.4734 12
+    endloop
+  endfacet
+  facet normal -0.248692 -0.968583 -0
+    outer loop
+      vertex -7.53647 11.4266 12
+      vertex -7.71893 11.4734 0
+      vertex -7.53647 11.4266 0
+    endloop
+  endfacet
+  facet normal -0.481754 -0.876307 0
+    outer loop
+      vertex -7.36133 11.3572 0
+      vertex -7.19626 11.2665 12
+      vertex -7.36133 11.3572 12
+    endloop
+  endfacet
+  facet normal -0.481754 -0.876307 -0
+    outer loop
+      vertex -7.19626 11.2665 12
+      vertex -7.36133 11.3572 0
+      vertex -7.19626 11.2665 0
+    endloop
+  endfacet
+  facet normal 0.904829 -0.425775 0
+    outer loop
+      vertex -9.39466 10.5522 12
+      vertex -9.31446 10.7226 0
+      vertex -9.31446 10.7226 12
+    endloop
+  endfacet
+  facet normal 0.904829 -0.425775 0
+    outer loop
+      vertex -9.31446 10.7226 0
+      vertex -9.39466 10.5522 12
+      vertex -9.39466 10.5522 0
+    endloop
+  endfacet
+  facet normal 0.844326 -0.535829 0
+    outer loop
+      vertex -9.31446 10.7226 12
+      vertex -9.21352 10.8817 0
+      vertex -9.21352 10.8817 12
+    endloop
+  endfacet
+  facet normal 0.844326 -0.535829 0
+    outer loop
+      vertex -9.21352 10.8817 0
+      vertex -9.31446 10.7226 12
+      vertex -9.31446 10.7226 0
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309019 0
+    outer loop
+      vertex -9.45287 10.373 12
+      vertex -9.39466 10.5522 0
+      vertex -9.39466 10.5522 12
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309019 0
+    outer loop
+      vertex -9.39466 10.5522 0
+      vertex -9.45287 10.373 12
+      vertex -9.45287 10.373 0
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex -8.95614 11.1558 0
+      vertex -8.80374 11.2665 12
+      vertex -8.95614 11.1558 12
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex -8.80374 11.2665 12
+      vertex -8.95614 11.1558 0
+      vertex -8.80374 11.2665 0
+    endloop
+  endfacet
+  facet normal 0.125333 -0.992115 0
+    outer loop
+      vertex -8.28107 11.4734 0
+      vertex -8.09418 11.497 12
+      vertex -8.28107 11.4734 12
+    endloop
+  endfacet
+  facet normal 0.125333 -0.992115 0
+    outer loop
+      vertex -8.09418 11.497 12
+      vertex -8.28107 11.4734 0
+      vertex -8.09418 11.497 0
+    endloop
+  endfacet
+  facet normal -0.125333 0.992115 0
+    outer loop
+      vertex -7.71893 8.52657 0
+      vertex -7.90581 8.50296 12
+      vertex -7.71893 8.52657 12
+    endloop
+  endfacet
+  facet normal -0.125333 0.992115 0
+    outer loop
+      vertex -7.90581 8.50296 12
+      vertex -7.71893 8.52657 0
+      vertex -7.90581 8.50296 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309019 0
+    outer loop
+      vertex -6.54712 10.373 0
+      vertex -6.60534 10.5522 12
+      vertex -6.60534 10.5522 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309019 0
+    outer loop
+      vertex -6.60534 10.5522 12
+      vertex -6.54712 10.373 0
+      vertex -6.54712 10.373 12
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex -6.78647 10.8817 0
+      vertex -6.90655 11.0268 12
+      vertex -6.90655 11.0268 0
+    endloop
+  endfacet
+  facet normal -0.770513 -0.637424 0
+    outer loop
+      vertex -6.90655 11.0268 12
+      vertex -6.78647 10.8817 0
+      vertex -6.78647 10.8817 12
+    endloop
+  endfacet
+  facet normal -0.844326 -0.535829 0
+    outer loop
+      vertex -6.68554 10.7226 0
+      vertex -6.78647 10.8817 12
+      vertex -6.78647 10.8817 0
+    endloop
+  endfacet
+  facet normal -0.844326 -0.535829 0
+    outer loop
+      vertex -6.78647 10.8817 12
+      vertex -6.68554 10.7226 0
+      vertex -6.68554 10.7226 12
+    endloop
+  endfacet
+  facet normal -0.125333 -0.992115 0
+    outer loop
+      vertex -7.90581 11.497 0
+      vertex -7.71893 11.4734 12
+      vertex -7.90581 11.497 12
+    endloop
+  endfacet
+  facet normal -0.125333 -0.992115 -0
+    outer loop
+      vertex -7.71893 11.4734 12
+      vertex -7.90581 11.497 0
+      vertex -7.71893 11.4734 0
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 0
+    outer loop
+      vertex -7.19626 11.2665 0
+      vertex -7.04386 11.1558 12
+      vertex -7.19626 11.2665 12
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 -0
+    outer loop
+      vertex -7.04386 11.1558 12
+      vertex -7.19626 11.2665 0
+      vertex -7.04386 11.1558 0
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex -9.21352 10.8817 12
+      vertex -9.09345 11.0268 0
+      vertex -9.09345 11.0268 12
+    endloop
+  endfacet
+  facet normal 0.770513 -0.637424 0
+    outer loop
+      vertex -9.09345 11.0268 0
+      vertex -9.21352 10.8817 12
+      vertex -9.21352 10.8817 0
+    endloop
+  endfacet
+  facet normal 0.982287 -0.187382 0
+    outer loop
+      vertex -9.48817 10.188 12
+      vertex -9.45287 10.373 0
+      vertex -9.45287 10.373 12
+    endloop
+  endfacet
+  facet normal 0.982287 -0.187382 0
+    outer loop
+      vertex -9.45287 10.373 0
+      vertex -9.48817 10.188 12
+      vertex -9.48817 10.188 0
+    endloop
+  endfacet
+  facet normal 0.248692 -0.968583 0
+    outer loop
+      vertex -8.46352 11.4266 0
+      vertex -8.28107 11.4734 12
+      vertex -8.46352 11.4266 12
+    endloop
+  endfacet
+  facet normal 0.248692 -0.968583 0
+    outer loop
+      vertex -8.28107 11.4734 12
+      vertex -8.46352 11.4266 0
+      vertex -8.28107 11.4734 0
+    endloop
+  endfacet
+  facet normal -0.998027 0.0627877 0
+    outer loop
+      vertex -6.51183 9.812 0
+      vertex -6.5 10 12
+      vertex -6.5 10 0
+    endloop
+  endfacet
+  facet normal -0.998027 0.0627877 0
+    outer loop
+      vertex -6.5 10 12
+      vertex -6.51183 9.812 0
+      vertex -6.51183 9.812 12
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex -6.90655 8.97318 0
+      vertex -6.78647 9.11832 12
+      vertex -6.78647 9.11832 0
+    endloop
+  endfacet
+  facet normal -0.770513 0.637424 0
+    outer loop
+      vertex -6.78647 9.11832 12
+      vertex -6.90655 8.97318 0
+      vertex -6.90655 8.97318 12
+    endloop
+  endfacet
+  facet normal 0.904829 0.425775 0
+    outer loop
+      vertex -9.31446 9.27737 12
+      vertex -9.39466 9.44781 0
+      vertex -9.39466 9.44781 12
+    endloop
+  endfacet
+  facet normal 0.904829 0.425775 0
+    outer loop
+      vertex -9.39466 9.44781 0
+      vertex -9.31446 9.27737 12
+      vertex -9.31446 9.27737 0
+    endloop
+  endfacet
+  facet normal -0.368126 0.929776 0
+    outer loop
+      vertex -7.36133 8.64276 0
+      vertex -7.53647 8.57341 12
+      vertex -7.36133 8.64276 12
+    endloop
+  endfacet
+  facet normal -0.368126 0.929776 0
+    outer loop
+      vertex -7.53647 8.57341 12
+      vertex -7.36133 8.64276 0
+      vertex -7.53647 8.57341 0
+    endloop
+  endfacet
+  facet normal 0.481754 -0.876307 0
+    outer loop
+      vertex -8.80374 11.2665 0
+      vertex -8.63867 11.3572 12
+      vertex -8.80374 11.2665 12
+    endloop
+  endfacet
+  facet normal 0.481754 -0.876307 0
+    outer loop
+      vertex -8.63867 11.3572 12
+      vertex -8.80374 11.2665 0
+      vertex -8.63867 11.3572 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309019 0
+    outer loop
+      vertex -6.60534 9.44781 0
+      vertex -6.54712 9.62696 12
+      vertex -6.54712 9.62696 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309019 0
+    outer loop
+      vertex -6.54712 9.62696 12
+      vertex -6.60534 9.44781 0
+      vertex -6.60534 9.44781 12
+    endloop
+  endfacet
+  facet normal -0.982287 0.187382 0
+    outer loop
+      vertex -6.54712 9.62696 0
+      vertex -6.51183 9.812 12
+      vertex -6.51183 9.812 0
+    endloop
+  endfacet
+  facet normal -0.982287 0.187382 0
+    outer loop
+      vertex -6.51183 9.812 12
+      vertex -6.54712 9.62696 0
+      vertex -6.54712 9.62696 12
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex -7.04386 8.84423 0
+      vertex -7.19626 8.73351 12
+      vertex -7.04386 8.84423 12
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex -7.19626 8.73351 12
+      vertex -7.04386 8.84423 0
+      vertex -7.19626 8.73351 0
+    endloop
+  endfacet
+  facet normal -0.684548 0.728968 0
+    outer loop
+      vertex -6.90655 8.97318 0
+      vertex -7.04386 8.84423 12
+      vertex -6.90655 8.97318 12
+    endloop
+  endfacet
+  facet normal -0.684548 0.728968 0
+    outer loop
+      vertex -7.04386 8.84423 12
+      vertex -6.90655 8.97318 0
+      vertex -7.04386 8.84423 0
+    endloop
+  endfacet
+  facet normal -0.904829 0.425775 0
+    outer loop
+      vertex -6.68554 9.27737 0
+      vertex -6.60534 9.44781 12
+      vertex -6.60534 9.44781 0
+    endloop
+  endfacet
+  facet normal -0.904829 0.425775 0
+    outer loop
+      vertex -6.60534 9.44781 12
+      vertex -6.68554 9.27737 0
+      vertex -6.68554 9.27737 12
+    endloop
+  endfacet
+  facet normal 0.368126 0.929776 -0
+    outer loop
+      vertex -8.46352 8.57341 0
+      vertex -8.63867 8.64276 12
+      vertex -8.46352 8.57341 12
+    endloop
+  endfacet
+  facet normal 0.368126 0.929776 0
+    outer loop
+      vertex -8.63867 8.64276 12
+      vertex -8.46352 8.57341 0
+      vertex -8.63867 8.64276 0
+    endloop
+  endfacet
+  facet normal 0.684548 0.728968 -0
+    outer loop
+      vertex -8.95614 8.84423 0
+      vertex -9.09345 8.97318 12
+      vertex -8.95614 8.84423 12
+    endloop
+  endfacet
+  facet normal 0.684548 0.728968 0
+    outer loop
+      vertex -9.09345 8.97318 12
+      vertex -8.95614 8.84423 0
+      vertex -9.09345 8.97318 0
+    endloop
+  endfacet
+  facet normal 0.951056 0.309019 0
+    outer loop
+      vertex -9.39466 9.44781 12
+      vertex -9.45287 9.62696 0
+      vertex -9.45287 9.62696 12
+    endloop
+  endfacet
+  facet normal 0.951056 0.309019 0
+    outer loop
+      vertex -9.45287 9.62696 0
+      vertex -9.39466 9.44781 12
+      vertex -9.39466 9.44781 0
+    endloop
+  endfacet
+  facet normal 0.998027 0.0627928 0
+    outer loop
+      vertex -9.48817 9.812 12
+      vertex -9.5 10 0
+      vertex -9.5 10 12
+    endloop
+  endfacet
+  facet normal 0.998027 0.0627928 0
+    outer loop
+      vertex -9.5 10 0
+      vertex -9.48817 9.812 12
+      vertex -9.48817 9.812 0
+    endloop
+  endfacet
+  facet normal -0.481754 0.876307 0
+    outer loop
+      vertex -7.19626 8.73351 0
+      vertex -7.36133 8.64276 12
+      vertex -7.19626 8.73351 12
+    endloop
+  endfacet
+  facet normal -0.481754 0.876307 0
+    outer loop
+      vertex -7.36133 8.64276 12
+      vertex -7.19626 8.73351 0
+      vertex -7.36133 8.64276 0
+    endloop
+  endfacet
+  facet normal -0.248692 0.968583 0
+    outer loop
+      vertex -7.53647 8.57341 0
+      vertex -7.71893 8.52657 12
+      vertex -7.53647 8.57341 12
+    endloop
+  endfacet
+  facet normal -0.248692 0.968583 0
+    outer loop
+      vertex -7.71893 8.52657 12
+      vertex -7.53647 8.57341 0
+      vertex -7.71893 8.52657 0
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 -0
+    outer loop
+      vertex -8.80374 8.73351 0
+      vertex -8.95614 8.84423 12
+      vertex -8.80374 8.73351 12
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 0
+    outer loop
+      vertex -8.95614 8.84423 12
+      vertex -8.80374 8.73351 0
+      vertex -8.95614 8.84423 0
+    endloop
+  endfacet
+  facet normal 0.248692 0.968583 -0
+    outer loop
+      vertex -8.28107 8.52657 0
+      vertex -8.46352 8.57341 12
+      vertex -8.28107 8.52657 12
+    endloop
+  endfacet
+  facet normal 0.248692 0.968583 0
+    outer loop
+      vertex -8.46352 8.57341 12
+      vertex -8.28107 8.52657 0
+      vertex -8.46352 8.57341 0
+    endloop
+  endfacet
+  facet normal 0.844326 0.535829 0
+    outer loop
+      vertex -9.21352 9.11832 12
+      vertex -9.31446 9.27737 0
+      vertex -9.31446 9.27737 12
+    endloop
+  endfacet
+  facet normal 0.844326 0.535829 0
+    outer loop
+      vertex -9.31446 9.27737 0
+      vertex -9.21352 9.11832 12
+      vertex -9.21352 9.11832 0
+    endloop
+  endfacet
+  facet normal 0.982287 0.187382 0
+    outer loop
+      vertex -9.45287 9.62696 12
+      vertex -9.48817 9.812 0
+      vertex -9.48817 9.812 12
+    endloop
+  endfacet
+  facet normal 0.982287 0.187382 0
+    outer loop
+      vertex -9.48817 9.812 0
+      vertex -9.45287 9.62696 12
+      vertex -9.45287 9.62696 0
+    endloop
+  endfacet
+  facet normal 0.481754 0.876307 -0
+    outer loop
+      vertex -8.63867 8.64276 0
+      vertex -8.80374 8.73351 12
+      vertex -8.63867 8.64276 12
+    endloop
+  endfacet
+  facet normal 0.481754 0.876307 0
+    outer loop
+      vertex -8.80374 8.73351 12
+      vertex -8.63867 8.64276 0
+      vertex -8.80374 8.73351 0
+    endloop
+  endfacet
+  facet normal 0.125333 0.992115 -0
+    outer loop
+      vertex -8.09418 8.50296 0
+      vertex -8.28107 8.52657 12
+      vertex -8.09418 8.50296 12
+    endloop
+  endfacet
+  facet normal 0.125333 0.992115 0
+    outer loop
+      vertex -8.28107 8.52657 12
+      vertex -8.09418 8.50296 0
+      vertex -8.28107 8.52657 0
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex -9.09345 8.97318 12
+      vertex -9.21352 9.11832 0
+      vertex -9.21352 9.11832 12
+    endloop
+  endfacet
+  facet normal 0.770513 0.637424 0
+    outer loop
+      vertex -9.21352 9.11832 0
+      vertex -9.09345 8.97318 12
+      vertex -9.09345 8.97318 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
Could you please accept this PR?
It gracefully handles the case where the user sets `pockets_depth   = 0`
and provides a Y Rod Holder stl file which should then be printed four times.
These pieces can be used tho hold the Y rods since there won't be any pockets for them to sit in.
